### PR TITLE
More mac fixes

### DIFF
--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -102,7 +102,19 @@ else
     GUROBI_ARGS="${GUROBI_ARGS} -DGUROBI_ROOT_DIR=${GUROBI_ROOT_DIR}"
     GUROBI_ARGS="${GUROBI_ARGS} -DGUROBI_LIBRARY=$(ls ${GUROBI_ROOT_DIR}/lib/libgurobi*.so)"
     GUROBI_ARGS="${GUROBI_ARGS} -DGUROBI_INCLUDE_DIR=${GUROBI_ROOT_DIR}/include"
-    GUROBI_ARGS="${GUROBI_ARGS} -DGUROBI_CPP_LIBRARY=${GUROBI_ROOT_DIR}/lib/libgurobi_c++.a"
+    
+    if [ $(uname) == "Darwin" ]; then    
+	    # Note: For Mac, the nice Gurobi people provide two versions of the gurobi library,
+	    #       depending on which version of the C++ std library you need to use:
+	    #       - For libstdc++ (from the GNU people), use libgurobi_stdc++.a
+	    #       - For libc++    (from the clang people), use libgurobi_c++.a
+	    #       We use gcc (even on Mac), so we use the libstdc++ version.
+	    GUROBI_ARGS="${GUROBI_ARGS} -DGUROBI_CPP_LIBRARY=${GUROBI_ROOT_DIR}/lib/libgurobi_stdc++.a"    
+    else
+        # Only one choice on Linux. It works with libstdc++ (from the GNU people).
+        # (The naming convention isn't consistent with the name on Mac, but that's okay.)
+        GUROBI_ARGS="${GUROBI_ARGS} -DGUROBI_CPP_LIBRARY=${GUROBI_ROOT_DIR}/lib/libgurobi_c++.a"    
+    fi
 fi
 
 ##

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -144,6 +144,8 @@ cmake .. \
         -DCMAKE_CXX_FLAGS_DEBUG="${CXXFLAGS}" \
 \
         -DBOOST_ROOT=${PREFIX} \
+        -DWITH_HDF5=ON \
+        -DHDF5_INCLUDE_DIR=${PREFIX}/include \
         ${CPLEX_ARGS} \
         ${GUROBI_ARGS} \
 \

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -43,6 +43,7 @@ requirements:
     - gcc 4.8.5 # [unix]
     - boost 1.55.0
     - python 2.7*
+    - hdf5 1.8.16
     
     {% if WITH_CPLEX is defined and WITH_CPLEX %}
     - cplex-shared # Need to make sure that cplex dylibs exist
@@ -57,6 +58,7 @@ requirements:
     - libgcc   4.8*
     - boost 1.55.0
     - python {{PY_VER}}*
+    - hdf5 1.8.16
     - numpy # Numpy version is not constrained, thanks to pybind11 magic
 
     {% if WITH_CPLEX is defined and WITH_CPLEX %}

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -48,6 +48,11 @@ requirements:
     - cplex-shared # Need to make sure that cplex dylibs exist
     {% endif %}
 
+    # Must provide symlinks so that the conda doesn't complain when it 'fixes' linking in _nifty.so
+    {% if WITH_GUROBI is defined and WITH_GUROBI %}
+    - gurobi-symlink
+    {% endif %}
+
   run:
     - libgcc   4.8*
     - boost 1.55.0

--- a/src/python/lib/CMakeLists.txt
+++ b/src/python/lib/CMakeLists.txt
@@ -130,7 +130,7 @@ elseif (UNIX)
     # Strip unnecessary sections of the binary on Linux/Mac OS
     if(APPLE)
         set_target_properties(_nifty PROPERTIES MACOSX_RPATH ".")
-        set_target_properties(_nifty PROPERTIES LINK_FLAGS "-undefined dynamic_lookup -dead_strip")
+        #set_target_properties(_nifty PROPERTIES LINK_FLAGS "-undefined dynamic_lookup -dead_strip")
         if (NOT ${U_CMAKE_BUILD_TYPE} MATCHES DEBUG)
             add_custom_command(TARGET _nifty POST_BUILD COMMAND strip -u -r ${CMAKE_CURRENT_BINARY_DIR}/_nifty.so)
         endif()

--- a/src/python/lib/CMakeLists.txt
+++ b/src/python/lib/CMakeLists.txt
@@ -97,6 +97,9 @@ endif()
 # Don't add a 'lib' prefix to the shared library
 set_target_properties(_nifty PROPERTIES PREFIX "")
 
+# Link against the Python shared library
+target_link_libraries(_nifty ${PYTHON_LIBRARY})
+
 if (WIN32)
     if (MSVC)
         # Enforce size-based optimization and link time code generation
@@ -108,8 +111,6 @@ if (WIN32)
     endif()
     # .PYD file extension on Windows
     set_target_properties(_nifty PROPERTIES SUFFIX ".pyd")
-    # Link against the Python shared library
-    target_link_libraries(_nifty ${PYTHON_LIBRARY})
 elseif (UNIX)
     # It's quite common to have multiple copies of the same Python version
     # installed on one's system. E.g.: one copy from the OS and another copy

--- a/src/python/module/__init__.py
+++ b/src/python/module/__init__.py
@@ -365,5 +365,11 @@ def __extendHdf5():
         array.__getitem__ = getItem
         array.__setitem__ = setItem
 
-__extendHdf5()
-del __extendHdf5
+try:
+    import hdf5
+except ImportError:
+    pass
+else:
+    __extendHdf5()
+finally:
+    del __extendHdf5


### PR DESCRIPTION
These changes just touch the cmake and conda scripts.  The only one you should look at closely is ab31814.  I think it makes sense to always link against `libpython.so` (it was required on my machine...), so I don't know how your build worked at all without this change.
