### PR TITLE
conda-recipe: Patch vigra so that std threading is properly detected under gcc-4.8

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -26,7 +26,9 @@ package:
 
 source:
   path: ../
-  git_tag: HEAD
+  patches:
+    # See https://github.com/ukoethe/vigra/issues/386
+    - patches/vigra-std-threading-detection.patch
 
 build:
   number: 0

--- a/conda-recipe/patches/vigra-std-threading-detection.patch
+++ b/conda-recipe/patches/vigra-std-threading-detection.patch
@@ -1,0 +1,11 @@
+--- externals/vigra/include/vigra/threading.hxx
++++ externals/vigra/include/vigra/threading.hxx
+@@ -49,7 +49,7 @@
+ #    define VIGRA_NO_STD_THREADING
+ #  endif
+ # else
+-#  if defined(__GNUC__) && (!defined(_GLIBCXX_HAS_GTHREADS) || !defined(_GLIBCXX_USE_C99_STDINT_TR1) || !defined(_GLIBCXX_USE_SCHED_YIELD))
++#  if defined(__GNUC__) && (!defined(_GLIBCXX_HAS_GTHREADS) || !defined(_GLIBCXX_USE_C99_STDINT_TR1))
+ #    define VIGRA_NO_STD_THREADING
+ #  endif
+ # endif


### PR DESCRIPTION
This is just a tweak to the conda recipe.  It patches vigra before the conda package is built.  This patch is needed to support my specific build of gcc-4.8.  If you want to know the details (you probably don't), see https://github.com/ukoethe/vigra/issues/386
