### PR TITLE
Fix test_multicut.cxx build failure.

### DIFF
--- a/src/test/test_graph/test_multicut.cxx
+++ b/src/test/test_graph/test_multicut.cxx
@@ -3,6 +3,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include <iostream> 
+#include <random>
 
 #include "nifty/tools/runtime_check.hxx"
 #include "nifty/graph/undirected_list_graph.hxx"


### PR DESCRIPTION
Build fails for `src/test/test_graph/CMakeFiles/test_multicut.dir/test_multicut.cxx.o` (see log below). Adding `#inlcude <random>` to `test_multicut.cxx` fixes this issue.

``` bash
hanslovskyp@saalfelds-ws2 ~/git/nifty/build (git)-[hmaster] % make
[  4%] Built target test_marray
Scanning dependencies of target test_multicut
[  6%] Building CXX object src/test/test_graph/CMakeFiles/test_multicut.dir/test_multicut.cxx.o
/home/hanslovskyp/git/nifty/src/test/test_graph/test_multicut.cxx: In member function ‘void RandomizedMulticutTest::test_method()’:
/home/hanslovskyp/git/nifty/src/test/test_graph/test_multicut.cxx:28:5: error: ‘mt19937’ is not a member of ‘std’
     std::mt19937 gen(42);//rd());
     ^~~
/home/hanslovskyp/git/nifty/src/test/test_graph/test_multicut.cxx:29:5: error: ‘uniform_real_distribution’ is not a member of ‘std’
     std::uniform_real_distribution<> dis(-1.0, 1.0);
     ^~~
/home/hanslovskyp/git/nifty/src/test/test_graph/test_multicut.cxx:29:36: error: expected primary-expression before ‘>’ token
     std::uniform_real_distribution<> dis(-1.0, 1.0);
                                    ^
/home/hanslovskyp/git/nifty/src/test/test_graph/test_multicut.cxx:29:51: error: ‘dis’ was not declared in this scope
     std::uniform_real_distribution<> dis(-1.0, 1.0);
                                                   ^
/home/hanslovskyp/git/nifty/src/test/test_graph/test_multicut.cxx:63:27: error: ‘gen’ was not declared in this scope
         weights[e] =  dis(gen);
                           ^~~
/home/hanslovskyp/git/nifty/src/test/test_graph/test_multicut.cxx: In member function ‘void SimpleMulticutTest::test_method()’:
/home/hanslovskyp/git/nifty/src/test/test_graph/test_multicut.cxx:123:5: error: ‘mt19937’ is not a member of ‘std’
     std::mt19937 gen(42);//rd());
     ^~~
/home/hanslovskyp/git/nifty/src/test/test_graph/test_multicut.cxx:124:5: error: ‘uniform_real_distribution’ is not a member of ‘std’
     std::uniform_real_distribution<> dis(-1.0, 1.0);
     ^~~
/home/hanslovskyp/git/nifty/src/test/test_graph/test_multicut.cxx:124:36: error: expected primary-expression before ‘>’ token
     std::uniform_real_distribution<> dis(-1.0, 1.0);
                                    ^
/home/hanslovskyp/git/nifty/src/test/test_graph/test_multicut.cxx:124:51: error: ‘dis’ was not declared in this scope
     std::uniform_real_distribution<> dis(-1.0, 1.0);
                                                   ^
make[2]: *** [src/test/test_graph/CMakeFiles/test_multicut.dir/build.make:63: src/test/test_graph/CMakeFiles/test_multicut.dir/test_multicut.cxx.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:182: src/test/test_graph/CMakeFiles/test_multicut.dir/all] Error 2
make: *** [Makefile:95: all] Error 2
```
