### PR TITLE
Fixes related to gurobi

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,11 +4,12 @@
     
 [submodule "externals/pybind11"]
 	path = externals/pybind11
-	url = https://github.com/DerThorsten/pybind11
+	url = https://github.com/pybind/pybind11
     
 [submodule "externals/vigra"]
 	path = externals/vigra
 	url = https://github.com/DerThorsten/vigra
+
 [submodule "externals/graph"]
 	path = externals/graph
 	url = https://github.com/bjoern-andres/graph

--- a/include/nifty/graph/optimization/visitor_base.hxx
+++ b/include/nifty/graph/optimization/visitor_base.hxx
@@ -5,6 +5,7 @@
 #include <string>
 #include <initializer_list>
 #include <sstream>
+#include <iostream>
 
 namespace nifty {
 namespace graph {

--- a/include/nifty/ilp_backend/gurobi.hxx
+++ b/include/nifty/ilp_backend/gurobi.hxx
@@ -7,7 +7,8 @@
 
 #include "gurobi_c++.h"
 
-#include "nifty/graph/optimization/multicut/ilp_backend/ilp_backend.hxx"
+#include "nifty/exceptions/exceptions.hxx"
+#include "nifty/ilp_backend/ilp_backend.hxx"
 
 namespace nifty {
 namespace ilp_backend{
@@ -40,7 +41,7 @@ public:
     void changeObjective(
         OBJECTIVE_ITERATOR objectiveIter
     ){
-        throw WeightsChangedNotSupported();
+        throw nifty::exceptions::WeightsChangedNotSupported();
 
     }
 

--- a/src/python/lib/nifty.cxx
+++ b/src/python/lib/nifty.cxx
@@ -1,12 +1,14 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
-#include <iostream>
+#include <sstream>
 
 #include "nifty/python/converter.hxx"
 
 namespace py = pybind11;
 
-
+#ifdef WITH_GUROBI
+    #include <gurobi_c++.h>
+#endif
 
 namespace nifty{
 namespace graph{
@@ -42,6 +44,21 @@ PYBIND11_PLUGIN(_nifty) {
 
     #ifdef WITH_HDF5
     hdf5::initSubmoduleHdf5(niftyModule);
+    #endif
+
+    #ifdef WITH_GUROBI
+        // Translate Gurobi exceptions to Python exceptions
+        // (Must do this explicitly since GRBException doesn't inherit from std::exception)
+        static py::exception<GRBException> exc(niftyModule, "GRBException");
+        py::register_exception_translator([](std::exception_ptr p) {
+            try {
+                if (p) std::rethrow_exception(p);
+            } catch (const GRBException &e) {
+                std::ostringstream ss;
+                ss << e.getMessage() << " (Error code:" << e.getErrorCode() << ")";
+                exc(ss.str().c_str());
+            }
+        });
     #endif
 
     // \TODO move to another header


### PR DESCRIPTION
- Made some minor fixes for includes/namespace
- Registered a translator for Gurobi exceptions so they can be shown in Python.
- To make an exception translator, I had to upgrade the version of pybind I was using.  I tried DerThorsten/pybind11:master, but with that version I ran into some compiler error.  I also tried using the latest tag (`v1.8.1`) tag of the official pybind11 repo, but that version seemed to have some problems, too.  Ultimately, the version that worked was the latest commit from the pybind11 repo.  So in this PR, I've changed the git submodule to point to `github.com/pybind/pybind11`, and pinned it to commit [68a9989](https://github.com/pybind/pybind11/commit/68a9989298635c46e08221812e201935c0e613be).

BTW, I think the exception translator is correct (I just copied the example from the pybind documentation), but I don't know for sure because the exception I was seeing in the old version of nifty apparently does not occur in the latest version.  (Yay!)
