### PR TITLE
Added missing call by reference in tools::readSubarray

### DIFF
--- a/include/nifty/hdf5/hdf5_array.hxx
+++ b/include/nifty/hdf5/hdf5_array.hxx
@@ -387,7 +387,7 @@ namespace tools{
 
     template<class T, class COORD>
     inline void readSubarray(
-        const hdf5::Hdf5Array<T> array,
+        const hdf5::Hdf5Array<T> & array,
         const COORD & beginCoord,
         const COORD & endCoord,
         marray::View<T> & subarray


### PR DESCRIPTION
The missing call by reference here has led to some nasty bugs, because the Hdf5Array is passed by value and then destroyed when the readSubarray scope is closed. 