### PR TITLE
Adding block offsets in grid_rag_accumulate::accumulateEdgeFeaturesWi…

### DIFF
--- a/include/nifty/graph/rag/grid_rag_accumulate.hxx
+++ b/include/nifty/graph/rag/grid_rag_accumulate.hxx
@@ -144,8 +144,8 @@ namespace graph{
                                 VigraCoord vigraCoordV;
 
                                 for(size_t d=0; d<DIM; ++d){
-                                    vigraCoordU[d] = coordU[d];
-                                    vigraCoordV[d] = coordV[d];
+                                    vigraCoordU[d] = coordU[d]+blockBegin[d];
+                                    vigraCoordV[d] = coordV[d]+blockBegin[d];
                                 }
 
                                 accVec[edge].updatePassN(dataU, vigraCoordU, pass);


### PR DESCRIPTION
Turns out adding the missing coordinate offset to the vigra coordinate was only missing in accumulateEdgeFeaturesWithAccChain.
Probably it doesn't really matter in there, but I fixed it anyway.