### PR TITLE
Remove np.squeeze in dimensionality check

### DIFF
--- a/src/python/module/nifty/graph/rag/__init__.py
+++ b/src/python/module/nifty/graph/rag/__init__.py
@@ -20,13 +20,13 @@ def gridRag(labels, numberOfThreads=-1, serialization = None):
     labels = numpy.require(labels ,dtype='uint32')
 
 
-    if numpy.squeeze(labels).ndim == 2:
+    if labels.ndim == 2:
         if serialization is None:
             return explicitLabelsGridRag2D(labels, numberOfThreads=int(numberOfThreads))
         else:
             return explicitLabelsGridRag2D(labels, serialization)
 
-    elif numpy.squeeze(labels).ndim == 3:
+    elif labels.ndim == 3:
         if serialization is None:
             return explicitLabelsGridRag3D(labels, numberOfThreads=int(numberOfThreads))
         else:


### PR DESCRIPTION
User should be responsible to pass array of correct dimensionality (2d or 3d)

This fixes #104 

Note that there is no python test for the grid rag python module.