### PR TITLE
Accept all np.unsignedinteger types in gridGraph, default to uint64 otherwise

### DIFF
--- a/src/python/lib/graph/rag/grid_rag.cxx
+++ b/src/python/lib/graph/rag/grid_rag.cxx
@@ -395,8 +395,17 @@ namespace graph{
 
     void exportGridRag(py::module & ragModule) {
 
-        exportExpilictGridRagT<2, uint32_t>(ragModule, "ExplicitLabelsGridRag2D", "explicitLabelsGridRag2D");
-        exportExpilictGridRagT<3, uint32_t>(ragModule, "ExplicitLabelsGridRag3D", "explicitLabelsGridRag3D");
+        exportExpilictGridRagT<2, uint8_t>(ragModule, "ExplicitLabelsGridRag2D_uint8", "explicitLabelsGridRag2D");
+        exportExpilictGridRagT<3, uint8_t>(ragModule, "ExplicitLabelsGridRag3D_uint8", "explicitLabelsGridRag3D");
+
+        exportExpilictGridRagT<2, uint16_t>(ragModule, "ExplicitLabelsGridRag2D_uint16", "explicitLabelsGridRag2D");
+        exportExpilictGridRagT<3, uint16_t>(ragModule, "ExplicitLabelsGridRag3D_uint16", "explicitLabelsGridRag3D");
+
+        exportExpilictGridRagT<2, uint32_t>(ragModule, "ExplicitLabelsGridRag2D_uint32", "explicitLabelsGridRag2D");
+        exportExpilictGridRagT<3, uint32_t>(ragModule, "ExplicitLabelsGridRag3D_uint32", "explicitLabelsGridRag3D");
+
+        exportExpilictGridRagT<2, uint64_t>(ragModule, "ExplicitLabelsGridRag2D", "explicitLabelsGridRag2D");
+        exportExpilictGridRagT<3, uint64_t>(ragModule, "ExplicitLabelsGridRag3D", "explicitLabelsGridRag3D");
 
         exportExplicitGridRagStacked2D<uint32_t>(ragModule, "GridRagStacked2DExplicit", "gridRagStacked2DExplicitImpl");
 

--- a/src/python/lib/graph/rag/grid_rag.cxx
+++ b/src/python/lib/graph/rag/grid_rag.cxx
@@ -407,6 +407,18 @@ namespace graph{
         exportExpilictGridRagT<2, uint64_t>(ragModule, "ExplicitLabelsGridRag2D", "explicitLabelsGridRag2D");
         exportExpilictGridRagT<3, uint64_t>(ragModule, "ExplicitLabelsGridRag3D", "explicitLabelsGridRag3D");
 
+        exportExpilictGridRagT<2, int8_t>(ragModule, "ExplicitLabelsGridRag2D_int8", "explicitLabelsGridRag2D");
+        exportExpilictGridRagT<3, int8_t>(ragModule, "ExplicitLabelsGridRag3D_int8", "explicitLabelsGridRag3D");
+
+        exportExpilictGridRagT<2, int16_t>(ragModule, "ExplicitLabelsGridRag2D_int16", "explicitLabelsGridRag2D");
+        exportExpilictGridRagT<3, int16_t>(ragModule, "ExplicitLabelsGridRag3D_int16", "explicitLabelsGridRag3D");
+
+        exportExpilictGridRagT<2, int32_t>(ragModule, "ExplicitLabelsGridRag2D_int32", "explicitLabelsGridRag2D");
+        exportExpilictGridRagT<3, int32_t>(ragModule, "ExplicitLabelsGridRag3D_int32", "explicitLabelsGridRag3D");
+
+        exportExpilictGridRagT<2, int64_t>(ragModule, "ExplicitLabelsGridRag2D_int64", "explicitLabelsGridRag2D");
+        exportExpilictGridRagT<3, int64_t>(ragModule, "ExplicitLabelsGridRag3D_int64", "explicitLabelsGridRag3D");
+
         exportExplicitGridRagStacked2D<uint32_t>(ragModule, "GridRagStacked2DExplicit", "gridRagStacked2DExplicitImpl");
 
         #ifdef WITH_HDF5

--- a/src/python/module/nifty/graph/rag/__init__.py
+++ b/src/python/module/nifty/graph/rag/__init__.py
@@ -17,8 +17,8 @@ for key in __rag.__dict__.keys():
 
 
 def gridRag(labels, numberOfThreads=-1, serialization = None):
-    labels = numpy.require(labels ,dtype='uint32')
 
+    labels = labels if numpy.issubdtype(labels.dtype, numpy.unsignedinteger) else numpy.require(labels, dtype=numpy.uint64)
 
     if labels.ndim == 2:
         if serialization is None:


### PR DESCRIPTION
This is a possible solution to #105 without changing the data type for all subtypes of `np.unsignedinteger`.

```python
import nifty.graph.rag as nrag
import numpy as np

This is an example:
dtypes = [np.uint8, np.uint16, np.uint32, np.uint64, np.int8, np.float32]
for dt in dtypes:
    a = np.zeros((1, 1, 1), dtype=dt)
    rag = nrag.gridRag( a )
    print( rag, type( rag ) )
```
Output:
```
#Nodes 1 #Edges 0 <class 'nifty.graph.rag.ExplicitLabelsGridRag3D_uint8'>
#Nodes 1 #Edges 0 <class 'nifty.graph.rag.ExplicitLabelsGridRag3D_uint16'>
#Nodes 1 #Edges 0 <class 'nifty.graph.rag.ExplicitLabelsGridRag3D_uint32'>
#Nodes 1 #Edges 0 <class 'nifty.graph.rag.ExplicitLabelsGridRag3D'>
#Nodes 1 #Edges 0 <class 'nifty.graph.rag.ExplicitLabelsGridRag3D'>
#Nodes 1 #Edges 0 <class 'nifty.graph.rag.ExplicitLabelsGridRag3D'>
```

This is just an idea of how `gridRag` could be relaxed to accept more types/all unsigned integer types. If you have any concerns about how I implemented this, let me know.