### PR TITLE
use specific numpy version

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -46,6 +46,7 @@ requirements:
     - boost >=1.63.0
     - python {{PY_VER}}*
     - hdf5 >=1.8.17
+    - numpy {{NPY_VER}}*
     - xtensor
     - xtensor-python
     {% if WITH_CPLEX is defined and WITH_CPLEX %}
@@ -61,7 +62,7 @@ requirements:
     - boost >=1.63.0
     - python {{PY_VER}}*
     - hdf5 >=1.8.17
-    - numpy
+    - numpy {{NPY_VER}}*
     - fastfilters
     - scikit-image
     - scipy


### PR DESCRIPTION
In contrast to a comment in one of the older versions of `meta.yaml` that suggested that "Numpy version is not constrained, thanks to pybind11 magic", I found that you 
  
1. need numpy at build time, and
2.  it only works at the moment as one of the dependent packages has numpy as a dependency.

The build will then be numpy API specific.

with this fix, you'll need to specify the numpy version with `--numpy=1.xx` in `conda build`.