### PR TITLE
Allow compilation with compatibility to the pre cpp11 gcc abi (gcc < 5)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,6 @@ set(${PROJECT_NAME}_VERSION
 message(STATUS "${PROJECT_NAME} v${${PROJECT_NAME}_VERSION}")
 
 
-# ADD_DEFINITIONS(-D_GLIBCXX_USE_CXX11_ABI=0)
-
 include(CheckCXXCompilerFlag)
 
 
@@ -42,7 +40,7 @@ option(WITH_FASTFILTERS OFF)
 option(WITH_LP_MP OFF)
 option(WITH_QPBO ON)
 
-option(BUILD_CPP_TEST_WITH_GLIBCXX_CXX11_ABI OFF)
+option(BUILD_WITH_GLIBCXX_CXX11_ABI "Use stdlibcxx11, for gcc >= 5, disable for gcc < 5" ON)
 
 option(BUILD_PYTHON_TEST OFF)
 option(BUILD_CPP_TEST ON)
@@ -56,6 +54,13 @@ option(REMOVE_SOME_WARNINGS "Remove some annoying warnings" ON)
 if(MSVC)
     # Disable autolinking on MSVC.
     add_definitions(-DBOOST_ALL_NO_LIB)
+endif()
+
+if(BUILD_WITH_GLIBCXX_CXX11_ABI)
+    ADD_DEFINITIONS(-D_GLIBCXX_USE_CXX11_ABI=1)
+else()
+    # Use old ABI, for compatibility with GCC < 5
+    ADD_DEFINITIONS(-D_GLIBCXX_USE_CXX11_ABI=0)
 endif()
 
 # from externals..

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -21,6 +21,14 @@ else
     export DYLIB="so"
 fi
 
+# Check which gcxx abi to use; for compatibility with libs build with gcc < 5:
+if [[ -z ${DO_NOT_BUILD_WITH_CXX11_ABI} ]]; then
+    CXX_ABI_ARGS="-DBUILD_WITH_CXX11_ABI=ON"
+else
+    # use the old ABI
+    CXX_ABI_ARGS="-DBUILD_WITH_CXX11_ABI=OFF"
+fi
+
 # Pre-define special flags, paths, etc. if we're building with CPLEX support.
 if [[ "$WITH_CPLEX" == "" ]]; then
     CPLEX_ARGS=""
@@ -155,6 +163,7 @@ cmake .. \
         -DCMAKE_CXX_FLAGS="${CXXFLAGS}" \
         -DCMAKE_CXX_FLAGS_RELEASE="${CXXFLAGS} -O3 -DNDEBUG" \
         -DCMAKE_CXX_FLAGS_DEBUG="${CXXFLAGS}" \
+        ${CXX_ABI_ARGS} \
 \
         -DBOOST_ROOT=${PREFIX} \
         -DWITH_HDF5=ON \

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -40,6 +40,7 @@ build:
      - CPLEX_ROOT_DIR
      - WITH_GUROBI
      - GUROBI_ROOT_DIR
+     - DO_NOT_BUILD_WITH_CXX11_ABI # [linux]
 
 requirements:
   build:

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -5,11 +5,6 @@
 
 SET(TEST_LIBS "")
 
-if(BUILD_CPP_TEST_WITH_GLIBCXX_CXX11_ABI)
-else()
-    ADD_DEFINITIONS(-D_GLIBCXX_USE_CXX11_ABI=0)
-endif()
-
 add_subdirectory(test_graph)
 add_subdirectory(test_array)
 add_subdirectory(test_features)


### PR DESCRIPTION
Linux: In order to stay compatible with packages built on conda-forge, and at the same time being able to use newer compiler and newer cpp features, we (ilastik team) need to be able to build nifty with the `_GLIBCXX_CXX11_ABI=0` flag.

Summary:
* added a cmake option `BUILD_WITH_GLIBCXX_CXX11_ABI` which is `ON` by default. This will add `-D_GLIBCXX_USE_CXX11_ABI=1` to compiler flags.
* modified conda recipe in order to pass through an environment variable `DO_NOT_BUILD_WITH_CXX11_ABI`. If this variable is set, it will set the `BUILD_WITH_GLIBCXX_CXX11_ABI` to `OFF`
