### PR TITLE
Removed unused absolute import, fixes build with solvers

### DIFF
--- a/src/python/module/nifty/graph/opt/lifted_multicut/__init__.py
+++ b/src/python/module/nifty/graph/opt/lifted_multicut/__init__.py
@@ -4,7 +4,6 @@ from ._lifted_multicut import *
 from functools import partial
 from ..multicut import ilpSettings
 from .. import Configuration
-import nifty.tools
 import numpy
 
 __all__ = []


### PR DESCRIPTION
absolute imports seem to break the nifty python package when used with solvers (-> package gets renamed, `import nifty. ...` will not work anymore )

This particular import was not used.